### PR TITLE
`get_cmhc` frequency handling

### DIFF
--- a/R/cmhc.R
+++ b/R/cmhc.R
@@ -146,12 +146,21 @@ get_cmhc <- function(survey,series, dimension, breakdown,geoFilter="Default",
   }
   if (!is.null(year)) {
     query_params$ForTimePeriod.Year=year
+    if (is.null(frequency)) {
+      query_params$Frequency="Annual"
+    }
   }
   if (!is.null(month)) {
     query_params$ForTimePeriod.Month=month
+    if (is.null(frequency)) {
+      query_params$Frequency="Monthly"
+    }
   }
   if (!is.null(quarter)) {
     query_params$ForTimePeriod.Quarter=quarter
+    if (is.null(frequency)) {
+      query_params$Frequency="Quarterly"
+    }
   }
 
   if (!is.null(frequency)) {


### PR DESCRIPTION
Automatically sets `frequency` based on the presence of `year`, `month`, or `quarter` inputs:
  - `Annual` when only `year` is provided.
  - `Monthly` when `month` is provided.
  - `Quarterly` when `quarter` is provided.
Order of precedence: if `quarter` is provided, frequency is `Quarterly`. If `month` is provided, it will be `Monthly`. If only `year` is provided, then `Annual`. The call will still respect the `year` input in all cases.

Retains support for user-specified `frequency` if explicitly provided.

Answers to https://github.com/mountainMath/cmhc/issues/21